### PR TITLE
Protect .github/ with CODEOWNERS (security hardening)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require org-admin review for CI/CD & repo automation changes
+/.github/ @mark-keaton @ddgoin


### PR DESCRIPTION
Adds `.github/CODEOWNERS` requiring review from @mark-keaton / @ddgoin for changes under `.github/` (CI/CD, GitHub Actions). Closes the workflow-tampering attack vector; enforced by the enterprise ruleset.